### PR TITLE
fix a minor bug on the sample application

### DIFF
--- a/Sample Shop Application/SampleShopApplication/api/controllers/homeController.js
+++ b/Sample Shop Application/SampleShopApplication/api/controllers/homeController.js
@@ -62,7 +62,7 @@ exports.PaymentSuccessReturnUrl = function(req, res) {
   var pdtRequestModel = new ypco.pdtRequestModel(pdtToken, params.TransactionId, params.MerchantOrderId, useSandbox);
   console.log('success url called');
   ypco.checkout.RequestPDT(pdtRequestModel).then((pdtJson) => {
-    if(pdtJson.Status = 'SUCCESS')
+    if(pdtJson.Status == 'SUCCESS')
     {
       console.log("success url called - Paid");
       //This means the payment is completed. 


### PR DESCRIPTION
the success endpoint status check always return `true` because the if check uses assignment(`=`) instead of `==`