### PR TITLE
bug in success result check

### DIFF
--- a/Sample Shop Application/SampleShopApplication/api/controllers/homeController.js
+++ b/Sample Shop Application/SampleShopApplication/api/controllers/homeController.js
@@ -54,7 +54,7 @@ exports.IPNDestination = function(req, res) {
   })
   .catch((err) => {
     res.json({ "Error" : err });
-  });;
+  });
 };
 
 exports.PaymentSuccessReturnUrl = function(req, res) {
@@ -62,7 +62,7 @@ exports.PaymentSuccessReturnUrl = function(req, res) {
   var pdtRequestModel = new ypco.pdtRequestModel(pdtToken, params.TransactionId, params.MerchantOrderId, useSandbox);
   console.log('success url called');
   ypco.checkout.RequestPDT(pdtRequestModel).then((pdtJson) => {
-    if(pdtJson.Status == 'SUCCESS')
+    if(pdtJson.result == 'SUCCESS') // or `pdtJson.Status == 'Paid'`
     {
       console.log("success url called - Paid");
       //This means the payment is completed. 


### PR DESCRIPTION
the resulting `pdtJson.Status` field is set `"Paid"` (not `"SUCCESS"`) upon successful transaction. Alternatively, we can check `pdtJson.result == "SUCCESS"`